### PR TITLE
PEP 8 cleanup, pass textfile dict to function scope

### DIFF
--- a/04 - Reserving/Data Simulation/_scripts/initialize.py
+++ b/04 - Reserving/Data Simulation/_scripts/initialize.py
@@ -71,14 +71,14 @@ def read_project(path: str):
         files read.
     :rtype: dict
     """
-    textcontent = {}
+    textfilecontent = {}
 
     # Discover .txt files and add them to the dictionary
     for filepath in iglob(os.path.join(path, '**/*.txt'), recursive=True):
-        add_path_dict(input_dict=textcontent, start_path=path,
+        add_path_dict(input_dict=textfilecontent, start_path=path,
                       file_path=filepath)
 
-    return textcontent
+    return textfilecontent
 
 
 # Add path argument for unzipping

--- a/04 - Reserving/Data Simulation/_scripts/simulation.py
+++ b/04 - Reserving/Data Simulation/_scripts/simulation.py
@@ -1,26 +1,38 @@
-def neural_network_1(var1, inputs, m):
+import numpy as np
 
-    q1 = list_of_variables.loc[list_of_variables['Variable'] == var1].iloc[:, 1]
-    q2 = list_of_variables.loc[list_of_variables['Variable'] == var1].iloc[:, 2]
-    d1 = list_of_variables.loc[list_of_variables['Variable'] == var1].iloc[:, 3:].sum(axis = 1)
-    d2 = list_of_variables.loc[list_of_variables['Variable'] == var1].iloc[:, 3:]
+
+def neural_network_1(var1, inputs, m, textfilecontent):
+
+    list_of_vars = textfilecontent['List.of.Variables']
+    variable_layer_sizes = list_of_vars.loc[list_of_vars['Variable'] == var1]
+
+    q1 = list_of_vars.loc[variable_layer_sizes].iloc[:, 1]
+    q2 = list_of_vars.loc[variable_layer_sizes].iloc[:, 2]
+    d1 = list_of_vars.loc[variable_layer_sizes].iloc[:, 3:].sum(axis=1)
+    d2 = list_of_vars.loc[variable_layer_sizes].iloc[:, 3:]
 
     data2 = np.ones((m, 1))
 
     for i in range(len(d2.columns)):
         if d2.iloc[0, i] == 1 and i in [0, 1, 5]:
-            translator = x['Translators'][var1][d2.columns[i]]
+            translator = textfilecontent['Translators'][var1][d2.columns[i]]
             data2 = np.hstack((data2, translator.loc[inputs[:, i]]))
         elif d2.iloc[0, i] == 1:
-            translator = x['Translators'][var1][d2.columns[i]]
-            temp = np.round(2 * np.minimum(np.maximum(inputs[:, i+1],
-                                                      np.array(translator.iloc[0, :])),
-                                           np.array(translator.iloc[1, :])) / int(translator.iloc[1, :] - translator.iloc[0, :]) - 1, 2).reshape(-1,1)
+            translator = textfilecontent['Translators'][var1][d2.columns[i]]
+            temp = np.round(
+                2 * np.minimum(
+                    np.maximum(
+                        inputs[:, i+1],
+                        np.array(translator.iloc[0, :])
+                    ),
+                    np.array(translator.iloc[1, :])
+                ) / int(translator.iloc[1, :] - translator.iloc[0, :]) - 1,
+                2).reshape(-1, 1)
             data2 = np.hstack((data2, temp))
 
-    beta = x['Parameters'][var1]['beta']
-    W1 = x['Parameters'][var1]['W1']
-    W2 = x['Parameters'][var1]['W2']
+    beta = textfilecontent['Parameters'][var1]['beta']
+    W1 = textfilecontent['Parameters'][var1]['W1']
+    W2 = textfilecontent['Parameters'][var1]['W2']
 
     z1_j = np.ones((int(q1)+1, m))
     z1_j[1:, :] = np.power(1 + np.exp(- W1.dot(np.transpose(data2))), -1)
@@ -28,4 +40,3 @@ def neural_network_1(var1, inputs, m):
     z2_j[1:, :] = np.power(1 + np.exp(- W2.dot(2 * z1_j - 1)), -1)
     mu_t = np.transpose(beta).dot(2 * z2_j - 1)
     return mu_t
-


### PR DESCRIPTION
I have cleaned up your function a bit and will follow approximately the same outline in my functions.

* always add imports at the top of modules which make use of them (vide `numpy` in our case)
* try to avoid global or higher-scope variables, pass everything to functions as arguments (`list_of_variables`)
* we can as well make use of the whole dict with textfiles loaded
* PEP8: limit line length to 79 characters, no spaces in argument-value pair (`axis=1`)

I have now requested your review of my pull request to your branch. You can press 'merge pull request' and my proposed changes will be incorporated into your code.